### PR TITLE
add precise to platforms

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,7 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
+        - precise
         - trusty
         - xenial
   galaxy_tags:


### PR DESCRIPTION
it works at least on our Ubuntu 12.04 systems installed via debootstrap minimal image
